### PR TITLE
Re-check the storequeue after the action is run

### DIFF
--- a/Thunker.js
+++ b/Thunker.js
@@ -138,7 +138,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	            return true;
 	          });
 
-	          return next(action);
+	          next(action);
+
+	          // re-check store after the action completes
+	          if (storeQueue.length) {
+	            storeQueue = storeQueue.filter(function (_ref5) {
+	              var _ref6 = _slicedToArray(_ref5, 2);
+
+	              var stateFn = _ref6[0];
+	              var cb = _ref6[1];
+
+	              if (stateFn(state)) {
+	                cb(state);
+	                return false;
+	              }
+
+	              return true;
+	            });
+	          }
 	        };
 	      };
 	    };

--- a/lib/modules/Thunker.js
+++ b/lib/modules/Thunker.js
@@ -49,7 +49,19 @@ export default {
         return true;
       });
 
-      return next(action);
+      next(action);
+
+      // re-check store after the action completes
+      if (storeQueue.length) {
+        storeQueue = storeQueue.filter(([stateFn, cb]) => {
+          if (stateFn(state)) {
+            cb(state);
+            return false;
+          }
+
+          return true;
+        });
+      }
     };
   },
 };


### PR DESCRIPTION
This solves an issue where an action is waitingForState, but the state change doesn't happen until the last action of a stack is fired. For example:
1. say we had an action with something like `waitForState(state => state.loading === false);`
2. N actions fire that don't touch `state.loading`
3. one action, at the very end, sets `loading = false`

Because the storequeue was checked _before_ this last action, the waitForState predicate never evaluates to true and so the action which is waiting for `state.loading === false` is never dispatched.

I copypasted this code, which should be written into a function instead of copypasted, to start discussion and confirm that this should be the intended behavior. This was causing odd behavior in a middleware I was writing that watched for `set_page`, and for `state.searchRequests[id].loading` to be false; the api response parsing was the last action fired in the stack, so the action never completed.

👓 @schwers @nramadas 
