### PR TITLE
Catch promise exceptions in `processQueue`.

### DIFF
--- a/PromiseWell.js
+++ b/PromiseWell.js
@@ -67,9 +67,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var p = queue[index];
 
 	      if (p) {
-	        p.then(function () {
+	        var processNext = function processNext() {
 	          return processQueue(index + 1, cb);
-	        });
+	        };
+	        // process the next item if we fail or not, so that onComplete
+	        // is guranteed to finish with as much data loaded as possible
+	        p.then(processNext).catch(processNext);
+	        // TODO: we need to revisit how this .catch fits in with node-platform's
+	        // Server.js. Developers already have to make use of `.catch` handlers
+	        // to deal with asyncronus errors in Promises, but platform/server
+	        // might want to expose an explicit `onRouteError` or `onAsyncActionError` callback
 	      } else {
 	        cb();
 	      }

--- a/lib/modules/PromiseWell.js
+++ b/lib/modules/PromiseWell.js
@@ -6,7 +6,16 @@ export default {
       const p = queue[index];
 
       if (p) {
-        p.then(() => processQueue(index + 1, cb));
+        const processNext = () => processQueue(index + 1, cb);
+        // process the next item if we fail or not, so that onComplete
+        // is guranteed to finish with as much data loaded as possible
+        p
+          .then(processNext)
+          .catch(processNext);
+        // TODO: we need to revisit how this .catch fits in with node-platform's
+        // Server.js. Developers already have to make use of `.catch` handlers
+        // to deal with asyncronus errors in Promises, but platform/server
+        // might want to expose an explicit `onRouteError` or `onAsyncActionError` callback
       } else {
         cb();
       }


### PR DESCRIPTION
Promise error handling is complex, this is a good example of such.
`processQueue` relies on `.then()` to continue process the queue
promises to resolve `PromseWell::onComplete`. If one of those
queue'd promises errors, the queue stalls and `node-platform`
based apps can hang on the server, leaving connections open
and users with a blank page forever (or until they hit 'stop').

👓 @phil303 @uzi 
